### PR TITLE
Singleton Design Pattern

### DIFF
--- a/src/main/java/DESIGNPATTERNS/Singleton/Runner.java
+++ b/src/main/java/DESIGNPATTERNS/Singleton/Runner.java
@@ -1,0 +1,16 @@
+package DESIGNPATTERNS.Singleton;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+public class Runner {
+    public static void main(String[] args) {
+        ExecutorService executorService = new ScheduledThreadPoolExecutor(10);
+        executorService.execute(TVSet::getTVSetInstance);
+        executorService.execute(TVSet::getTVSetInstance);
+        executorService.execute(TVSet::getTVSetInstance);
+        executorService.execute(TVSet::getTVSetInstance);
+        executorService.execute(TVSet::getTVSetInstance);
+        executorService.execute(TVSet::getTVSetInstance);
+    }
+}

--- a/src/main/java/DESIGNPATTERNS/Singleton/TVSet.java
+++ b/src/main/java/DESIGNPATTERNS/Singleton/TVSet.java
@@ -1,0 +1,20 @@
+package DESIGNPATTERNS.Singleton;
+
+public class TVSet {
+    private static volatile TVSet tvSetInstance = null;
+
+    private TVSet() {
+        System.out.println("Class Instantiated");
+    }
+
+    public static TVSet getTVSetInstance() {
+        if(tvSetInstance == null) {
+            synchronized (TVSet.class) {
+                if(tvSetInstance == null) {
+                    tvSetInstance = new TVSet();
+                }
+            }
+        }
+        return tvSetInstance;
+    }
+}


### PR DESCRIPTION
Introduction to Singleton Design Pattern :

It states that : “The end-users/ clients should be restricted to create numerous objects around the whole application . That is , the class should be allowed to be instantiated once.”

Normally , we can create numerous objects in our java-code , Like this :

```java
public class TVSet {
    public TVSet() {
    }
}

public class Runner {
    public static void main(String[] args) {
        TVSet tvSet1 = new TVSet();
        TVSet tvSet2 = new TVSet();
        System.out.println(tvSet1);
        System.out.println(tvSet2);
    }
}

==================== Output ==========================
DESIGNPATTERNS.Singleton.TVSet@5acf9800
DESIGNPATTERNS.Singleton.TVSet@4617c264
```

How can we create a Singleton Class ?

1. Make the constructor private
2. Create a method called getTVInstance() , which will create a new object 
3. But how can we call the getTVInstance() method if we do not create an object of the same class . This is possible by making the method static , as well as the variable .

```java
public class TVSet {
    private static TVSet tvSetInstance = null;

    private TVSet() {
        System.out.println("Class Instantiated");
    }

    public static TVSet getTVSetInstance() {
        if(tvSetInstance == null) {
            tvSetInstance = new TVSet();
        }
        return tvSetInstance;
    }
}

public class Runner {
    public static void main(String[] args) {
        TVSet tvSet1 = TVSet.getTVSetInstance();
        TVSet tvSet2 = TVSet.getTVSetInstance();
        System.out.println(tvSet1);
        System.out.println(tvSet2);
    }
}
```

But is it thread-safe ? 

```java
public static void main(String[] args) {
        ExecutorService executorService = new ScheduledThreadPoolExecutor(10);
        executorService.execute(TVSet::getTVSetInstance);
        executorService.execute(TVSet::getTVSetInstance);
        executorService.execute(TVSet::getTVSetInstance);
        executorService.execute(TVSet::getTVSetInstance);
        executorService.execute(TVSet::getTVSetInstance);
        executorService.execute(TVSet::getTVSetInstance);
    }
}

======================  Output  ============================

Class Instantiated
Class Instantiated
```

Here two times the class are instantiated , which shouldn’t be allowed .

We will make it thread-safe by :

1. Introducing a synchronised keyword - At a time , we will be allowing a single thread to execute a block of code .
2. Introducing a double check 

```java
public class TVSet {
    private static volatile TVSet tvSetInstance = null;

    private TVSet() {
        System.out.println("Class Instantiated");
    }

    public static TVSet getTVSetInstance() {
        if(tvSetInstance == null) {
            synchronized (TVSet.class) {
                if(tvSetInstance == null) {
                    tvSetInstance = new TVSet();        
                }
            }
        }
        return tvSetInstance;
    }
}
```